### PR TITLE
Fix persistenceStore class name in deployment.yaml files

### DIFF
--- a/modules/distribution/carbon-home/conf/server/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/server/deployment.yaml
@@ -303,7 +303,7 @@ state.persistence:
   enabled: false
   intervalInMin: 1
   revisionsToKeep: 2
-  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.FileSystemPersistenceStore
+  persistenceStore: org.wso2.carbon.streaming.integrator.core.persistence.FileSystemPersistenceStore
   config:
     location: siddhi-app-persistence
 

--- a/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/deployment-ha-node-1.yaml
+++ b/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/deployment-ha-node-1.yaml
@@ -299,7 +299,7 @@ state.persistence:
   enabled: true
   intervalInMin: 1
   revisionsToKeep: 3
-  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  persistenceStore: org.wso2.carbon.streaming.integrator.core.persistence.DBPersistenceStore
   # config:
     # location: siddhi-app-persistence
   config:

--- a/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/deployment-ha-node-2.yaml
+++ b/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/deployment-ha-node-2.yaml
@@ -299,7 +299,7 @@ state.persistence:
   enabled: true
   intervalInMin: 1
   revisionsToKeep: 3
-  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  persistenceStore: org.wso2.carbon.streaming.integrator.core.persistence.DBPersistenceStore
   # config:
     # location: siddhi-app-persistence
   config:

--- a/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/deployment-mysql.yaml
+++ b/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/deployment-mysql.yaml
@@ -186,7 +186,7 @@ state.persistence:
   enabled: false
   intervalInMin: 1
   revisionsToKeep: 3
-  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  persistenceStore: org.wso2.carbon.streaming.integrator.core.persistence.DBPersistenceStore
   # config:
     # location: siddhi-app-persistence
   config:


### PR DESCRIPTION
## Purpose
Fix persistenceStore class name in deployment.yaml files.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes