### PR TITLE
bump docker maven plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -820,7 +820,7 @@
 
         <testng.version>6.9.4</testng.version>
         <plugin.version.antlr>4.5.1</plugin.version.antlr>
-        <docker.maven.plugin.version>1.0.0</docker.maven.plugin.version>
+        <docker.maven.plugin.version>1.2.1</docker.maven.plugin.version>
 
         <!-- OSGI -->
         <osgi.api.version>6.0.0</osgi.api.version>


### PR DESCRIPTION
## Purpose
fix the following error when building SI docker image using "mvn clean install -Ddocker.skip=false"

Error:
com.spotify.docker.client.shaded.com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of com.spotify.docker.client.messages.RegistryAuth: no String-argument constructor/factory method to deserialize from String value ('swarm')

Related Issue: 
https://github.com/spotify/docker-maven-plugin/issues/350

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes