### PR TITLE
Add support for Java 11

### DIFF
--- a/modules/distribution/carbon-home/runtime/server/carbon.bat
+++ b/modules/distribution/carbon-home/runtime/server/carbon.bat
@@ -146,13 +146,13 @@ rem find the version of the jdk
 set CMD=RUN %*
 
 :checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
 IF ERRORLEVEL 1 goto unknownJdk
 goto jdk16
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
 goto jdk16
 
 :jdk16
@@ -167,9 +167,16 @@ rem ---------- Add jars to classpath ----------------
 
 set CARBON_CLASSPATH="%CARBON_HOME%\bin\bootstrap\*";%CARBON_CLASSPATH%
 
+PATH %PATH%;%JAVA_HOME%\bin\
+for /f tokens^=2-5^ delims^=.-_^" %%j in ('java -fullversion 2^>^&1') do set "jver=%%j%%k%%l%%m"
+
+set JAVA_VER_BASED_OPTS
+
 set JAVA_ENDORSED="%CARBON_HOME%\bin\bootstrap\endorsed";"%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8 -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
+if %jver% LSS 11000 set JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=%JAVA_ENDORSED_DIRS%"
+
+set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% %JAVA_VER_BASED_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8  -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
 
 :runJava
 echo JAVA_HOME environment variable is set to %JAVA_HOME%


### PR DESCRIPTION
## Purpose
Add support for Java 11

## Release note
Support for Java 11 for Windows environments.

## Test environment
java version "11.0.4" 2019-07-16 LTS
Java(TM) SE Runtime Environment 18.9 (build 11.0.4+10-LTS)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.4+10-LTS, mixed mode)

Windows 10 Pro