### PR TITLE
Bump Carbon Analytics and Carbon Kernel versions

### DIFF
--- a/modules/distribution/carbon-home/bin/server.bat
+++ b/modules/distribution/carbon-home/bin/server.bat
@@ -53,6 +53,9 @@ rem find CARBON_HOME if it does not exist due to either an invalid value passed
 rem by the user or the %0 problem on Windows 9x
 if not exist "%CARBON_HOME%\bin\version.txt" goto noServerHome
 
+rem Installing jars
+java -cp ".\*;%CARBON_HOME%\bin\tools\*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "%CARBON_HOME%"
+
 goto startServer
 
 :noServerHome

--- a/modules/distribution/carbon-home/bin/server.sh
+++ b/modules/distribution/carbon-home/bin/server.sh
@@ -55,6 +55,9 @@ PRGDIR=`dirname "$PRG"`
 
 [ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$PRGDIR/../wso2/server" ; pwd`
 
+# Installing jars
+java -cp "$CARBON_HOME/bin/tools/*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "$CARBON_HOME"
+
 ###########################################################################
 NAME=start-worker
 # Daemon name, where is the actual executable

--- a/pom.xml
+++ b/pom.xml
@@ -816,7 +816,7 @@
         </pluginManagement>
     </build>
     <properties>
-        <carbon.analytics.version>3.0.13</carbon.analytics.version>
+        <carbon.analytics.version>3.0.34</carbon.analytics.version>
         <siddhi.version>5.1.5</siddhi.version>
 
         <carbon.analytics-common.version>6.1.35</carbon.analytics-common.version>
@@ -842,7 +842,7 @@
 
         <!-- Dependencies -->
         <open.tracing.version>0.31.0</open.tracing.version>
-        <carbon.kernel.version>5.2.8</carbon.kernel.version>
+        <carbon.kernel.version>5.2.12</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.2.0, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.8</carbon.kernel.pax.version>
 


### PR DESCRIPTION
## Purpose
> - Bump Carbon Analytics and Carbon Kernel versions
> - Add capability to run `install-jars` tool (added with the kernel bump) at startup.

## Related PRs
> https://github.com/wso2/streaming-integrator-tooling/pull/53/files