### PR TITLE
Add Java 11 support and fix wso2/streaming-integrator#40

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -1076,16 +1076,16 @@
                         </configuration>
                     </execution>
                     <!-- TODO Enable after configuring Jenkins to push docker -->
-                    <!--<execution>-->
-                    <!--<id>push-image</id>-->
-                    <!--<phase>deploy</phase>-->
-                    <!--<goals>-->
-                    <!--<goal>push</goal>-->
-                    <!--</goals>-->
-                    <!--<configuration>-->
-                    <!--<imageName>wso2/micro-integrator:${project.version}</imageName>-->
-                    <!--</configuration>-->
-                    <!--</execution>-->
+<!--                    <execution>-->
+<!--                    <id>push-image</id>-->
+<!--                    <phase>deploy</phase>-->
+<!--                    <goals>-->
+<!--                    <goal>push</goal>-->
+<!--                    </goals>-->
+<!--                    <configuration>-->
+<!--                    <imageName>wso2/streaming-integrator:${project.version}</imageName>-->
+<!--                    </configuration>-->
+<!--                    </execution>-->
                 </executions>
             </plugin>
         </plugins>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -452,6 +452,57 @@
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy2</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <!--Java 11 related dependencies-->
+                                <artifactItem>
+                                    <groupId>javax.annotation</groupId>
+                                    <artifactId>javax.annotation-api</artifactId>
+                                    <version>${javax.annotation.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+                                    <artifactId>jaxb-api</artifactId>
+                                    <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.bind</groupId>
+                                    <artifactId>jaxb-impl</artifactId>
+                                    <version>${com.sun.xml.bind.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.geronimo.specs</groupId>
+                                    <artifactId>geronimo-activation_1.1_spec</artifactId>
+                                    <version>${org.apache.geronimo.spec.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.istack</groupId>
+                                    <artifactId>istack-commons-runtime</artifactId>
+                                    <version>${com.sun.istack.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.activation</groupId>
+                                    <artifactId>javax.activation</artifactId>
+                                    <version>${com.sun.activation.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/java-dependencies</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -326,51 +326,9 @@
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>io.siddhi.extension.execution.unique</groupId>
-                                    <artifactId>siddhi-execution-unique</artifactId>
-                                    <version>${siddhi.execution.unique.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.execution.regex</groupId>
-                                    <artifactId>siddhi-execution-regex</artifactId>
-                                    <version>${siddhi.execution.regex.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.execution.streamingml</groupId>
-                                    <artifactId>siddhi-execution-streamingml</artifactId>
-                                    <version>${siddhi.execution.streamingml.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.execution.markov</groupId>
-                                    <artifactId>siddhi-execution-markov</artifactId>
-                                    <version>${siddhi.execution.markov.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.execution.map</groupId>
-                                    <artifactId>siddhi-execution-map</artifactId>
-                                    <version>${siddhi.execution.map.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.execution.graph</groupId>
-                                    <artifactId>siddhi-execution-graph</artifactId>
-                                    <version>${siddhi.execution.graph.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>io.siddhi.extension.execution.math</groupId>
                                     <artifactId>siddhi-execution-math</artifactId>
                                     <version>${siddhi.execution.math.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.execution.timeseries</groupId>
-                                    <artifactId>siddhi-execution-timeseries</artifactId>
-                                    <version>${siddhi.execution.timeseries.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
@@ -380,48 +338,13 @@
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>io.siddhi.extension.execution.unitconversion</groupId>
-                                    <artifactId>siddhi-execution-unitconversion</artifactId>
-                                    <version>${siddhi.execution.unitconversion.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.execution.env</groupId>
-                                    <artifactId>siddhi-execution-env</artifactId>
-                                    <version>${siddhi.execution.env.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>io.siddhi.extension.execution.json</groupId>
                                     <artifactId>siddhi-execution-json</artifactId>
                                     <version>${siddhi.execution.json.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.execution.stats</groupId>
-                                    <artifactId>siddhi-execution-stats</artifactId>
-                                    <version>${siddhi.execution.stats.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.execution.list</groupId>
-                                    <artifactId>siddhi-execution-list</artifactId>
-                                    <version>${siddhi.execution.list.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
+
                                 <!--IO Extensions-->
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.jms</groupId>
-                                    <artifactId>siddhi-io-jms</artifactId>
-                                    <version>${siddhi.io.jms.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.rabbitmq</groupId>
-                                    <artifactId>siddhi-io-rabbitmq</artifactId>
-                                    <version>${siddhi.io.rabbitmq.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
                                 <artifactItem>
                                     <groupId>io.siddhi.extension.io.email</groupId>
                                     <artifactId>siddhi-io-email</artifactId>
@@ -453,18 +376,6 @@
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.io.twitter</groupId>
-                                    <artifactId>siddhi-io-twitter</artifactId>
-                                    <version>${siddhi.io.twitter.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.sqs</groupId>
-                                    <artifactId>siddhi-io-sqs</artifactId>
-                                    <version>${siddhi.io.sqs.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>io.siddhi.extension.io.websocket</groupId>
                                     <artifactId>siddhi-io-websocket</artifactId>
                                     <version>${siddhi.io.websocket.version}</version>
@@ -477,51 +388,9 @@
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>io.siddhi.extension.io.prometheus</groupId>
-                                    <artifactId>siddhi-io-prometheus</artifactId>
-                                    <version>${siddhi.io.prometheus.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.nats</groupId>
-                                    <artifactId>siddhi-io-nats</artifactId>
-                                    <version>${siddhi.io.nats.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.googlepubsub</groupId>
-                                    <artifactId>siddhi-io-googlepubsub</artifactId>
-                                    <version>${siddhi.io.googlepubsub.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.hl7</groupId>
-                                    <artifactId>siddhi-io-hl7</artifactId>
-                                    <version>${siddhi.io.hl7.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.io.snmp</groupId>
-                                    <artifactId>siddhi-io-snmp</artifactId>
-                                    <version>${siddhi.io.snmp.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>io.siddhi.extension.io.grpc</groupId>
                                     <artifactId>siddhi-io-grpc</artifactId>
                                     <version>${siddhi.io.grpc.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.gcs</groupId>
-                                    <artifactId>siddhi-io-gcs</artifactId>
-                                    <version>${siddhi.io.gcs.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.s3</groupId>
-                                    <artifactId>siddhi-io-s3</artifactId>
-                                    <version>${siddhi.io.s3.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
                                 <!--Map Extensions-->
@@ -536,12 +405,6 @@
                                     <groupId>io.siddhi.extension.map.json</groupId>
                                     <artifactId>siddhi-map-json</artifactId>
                                     <version>${siddhi.map.json.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.map.avro</groupId>
-                                    <artifactId>siddhi-map-avro</artifactId>
-                                    <version>${siddhi.map.avro.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
@@ -570,58 +433,9 @@
                                 </artifactItem>
                                 <!--Store Extensions-->
                                 <artifactItem>
-                                    <groupId>io.siddhi.extension.store.mongodb</groupId>
-                                    <artifactId>siddhi-store-mongodb</artifactId>
-                                    <version>${siddhi.store.mongodb.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>io.siddhi.extension.store.rdbms</groupId>
                                     <artifactId>siddhi-store-rdbms</artifactId>
                                     <version>${siddhi.store.rdbms.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.store.solr</groupId>
-                                    <artifactId>siddhi-store-solr</artifactId>
-                                    <version>${siddhi.store.solr.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.store.hbase</groupId>
-                                    <artifactId>siddhi-store-hbase</artifactId>
-                                    <version>${siddhi.store.hbase.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.store.cassandra</groupId>
-                                    <artifactId>siddhi-store-cassandra</artifactId>
-                                    <version>${siddhi.store.cassandra.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.store.redis</groupId>
-                                    <artifactId>siddhi-store-redis</artifactId>
-                                    <version>${siddhi.store.redis.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.io.mqtt</groupId>
-                                    <artifactId>siddhi-io-mqtt</artifactId>
-                                    <version>${siddhi.io.mqtt.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.siddhi.extension.store.elasticsearch</groupId>
-                                    <artifactId>siddhi-store-elasticsearch</artifactId>
-                                    <version>${siddhi.store.elasticsearch.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.store.influxdb</groupId>
-                                    <artifactId>siddhi-store-influxdb</artifactId>
-                                    <version>${siddhi.store.influxdb.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
 

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -199,6 +199,15 @@
             <outputDirectory>bin/</outputDirectory>
             <fileMode>744</fileMode>
         </fileSet>
+        <!-- Java 11 Dependencies -->
+        <fileSet>
+            <directory>target/java-dependencies</directory>
+            <outputDirectory>bin/bootstrap</outputDirectory>
+            <includes>
+                <include>**/*.jar</include>
+            </includes>
+            <fileMode>644</fileMode>
+        </fileSet>
     </fileSets>
     <files>
         <file>

--- a/modules/distribution/src/docker-distribution/filtered/Dockerfile
+++ b/modules/distribution/src/docker-distribution/filtered/Dockerfile
@@ -43,7 +43,7 @@ USER ${USER}
 WORKDIR ${USER_HOME}
 
 # expose streaming-integrator ports
-EXPOSE 7443 7070 9717 9612 7711 7611
+EXPOSE 7443 7070 9090 9443 7711 7611
 
 # initiate container and execute the streaming integrator product startup script
 ENTRYPOINT ["/home/wso2carbon/wso2si/bin/server.sh"]

--- a/modules/integration/tests-kubernetes-integration/pom.xml
+++ b/modules/integration/tests-kubernetes-integration/pom.xml
@@ -132,8 +132,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <properties>
-        <!-->todo please remove find bug exclude after doing the fixes in DeploymentConfigurationReader<-->
-        <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
-    </properties>
 </project>

--- a/modules/kubenetes/01-siddhi-operator.yaml
+++ b/modules/kubenetes/01-siddhi-operator.yaml
@@ -12,22 +12,22 @@ data:
   # ingressTLS: siddhi-tls
 ---
 
-# Deployment of the siddhi operator
+# Deployment of the streaming integrator
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: siddhi-operator
+  name: streaming-integrator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: siddhi-operator
+      name: streaming-integrator
   template:
     metadata:
       labels:
-        name: siddhi-operator
+        name: streaming-integrator
     spec:
-      serviceAccountName: siddhi-operator
+      serviceAccountName: streaming-integrator
       containers:
         - name: siddhi-operator
           image: siddhiio/siddhi-operator:0.2.0-beta

--- a/pom.xml
+++ b/pom.xml
@@ -952,60 +952,29 @@
 
         <!--Siddhi Extension Versions-->
         <siddhi.execution.math.version>5.0.4</siddhi.execution.math.version>
-        <siddhi.execution.unitconversion.version>2.0.2</siddhi.execution.unitconversion.version>
-        <siddhi.execution.regex.version>5.0.5</siddhi.execution.regex.version>
-        <siddhi.execution.streamingml.version>2.0.2</siddhi.execution.streamingml.version>
         <siddhi.execution.string.version>5.0.5</siddhi.execution.string.version>
         <siddhi.execution.time.version>5.0.4</siddhi.execution.time.version>
-        <siddhi.execution.unique.version>5.0.4</siddhi.execution.unique.version>
-        <siddhi.execution.timeseries.version>5.0.1</siddhi.execution.timeseries.version>
-
-        <siddhi.execution.markov.version>5.0.1</siddhi.execution.markov.version>
         <siddhi.execution.geo.version>5.0.0</siddhi.execution.geo.version>
-        <siddhi.execution.map.version>5.0.5</siddhi.execution.map.version>
-        <siddhi.execution.graph.version>2.0.0</siddhi.execution.graph.version>
-        <siddhi.execution.env.version>2.0.0</siddhi.execution.env.version>
         <siddhi.execution.json.version>2.0.2</siddhi.execution.json.version>
-        <siddhi.execution.stats.version>2.0.0</siddhi.execution.stats.version>
-        <siddhi.execution.list.version>1.0.0</siddhi.execution.list.version>
 
         <siddhi.io.file.version>2.0.3</siddhi.io.file.version>
         <siddhi.io.tcp.version>3.0.4</siddhi.io.tcp.version>
-        <siddhi.io.jms.version>2.0.2</siddhi.io.jms.version>
         <siddhi.io.email.version>2.0.3</siddhi.io.email.version>
-        <siddhi.io.rabbitmq.version>3.0.2</siddhi.io.rabbitmq.version>
-        <siddhi.io.mqtt.version>3.0.0</siddhi.io.mqtt.version>
         <siddhi.io.kafka.version>5.0.4</siddhi.io.kafka.version>
         <siddhi.io.http.version>2.2.0</siddhi.io.http.version>
-        <siddhi.io.twitter.version>2.0.0</siddhi.io.twitter.version>
-        <siddhi.io.sqs.version>3.0.0</siddhi.io.sqs.version>
         <siddhi.io.websocket.version>3.0.0</siddhi.io.websocket.version>
         <siddhi.io.cdc.version>2.0.3</siddhi.io.cdc.version>
-        <siddhi.io.prometheus.version>2.1.0</siddhi.io.prometheus.version>
         <siddhi.io.nats.version>2.0.6</siddhi.io.nats.version>
-        <siddhi.io.googlepubsub.version>2.0.2</siddhi.io.googlepubsub.version>
-        <siddhi.io.hl7.version>3.0.0</siddhi.io.hl7.version>
-        <siddhi.io.snmp.version>2.0.0</siddhi.io.snmp.version>
         <siddhi.io.grpc.version>1.0.3</siddhi.io.grpc.version>
-        <siddhi.io.gcs.version>1.0.0</siddhi.io.gcs.version>
-        <siddhi.io.s3.version>1.0.1</siddhi.io.s3.version>
 
         <siddhi.map.json.version>5.0.4</siddhi.map.json.version>
-        <siddhi.map.avro.version>2.0.5</siddhi.map.avro.version>
         <siddhi.map.binary.version>2.0.4</siddhi.map.binary.version>
         <siddhi.map.text.version>2.0.4</siddhi.map.text.version>
         <siddhi.map.xml.version>5.0.3</siddhi.map.xml.version>
         <siddhi.map.keyvalue.version>2.0.4</siddhi.map.keyvalue.version>
         <siddhi.map.csv.version>2.0.3</siddhi.map.csv.version>
 
-        <siddhi.store.mongodb.version>2.0.2</siddhi.store.mongodb.version>
         <siddhi.store.rdbms.version>6.0.4</siddhi.store.rdbms.version>
-        <siddhi.store.solr.version>2.0.0</siddhi.store.solr.version>
-        <siddhi.store.hbase.version>5.0.0</siddhi.store.hbase.version>
-        <siddhi.store.cassandra.version>2.0.0</siddhi.store.cassandra.version>
-        <siddhi.store.redis.version>3.1.1</siddhi.store.redis.version>
-        <siddhi.store.elasticsearch.version>3.1.1</siddhi.store.elasticsearch.version>
-        <siddhi.store.influxdb.version>2.0.0</siddhi.store.influxdb.version>
 
         <siddhi.script.js.version>5.0.2</siddhi.script.js.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -976,7 +976,7 @@
         <siddhi.io.rabbitmq.version>3.0.2</siddhi.io.rabbitmq.version>
         <siddhi.io.mqtt.version>3.0.0</siddhi.io.mqtt.version>
         <siddhi.io.kafka.version>5.0.4</siddhi.io.kafka.version>
-        <siddhi.io.http.version>2.1.0</siddhi.io.http.version>
+        <siddhi.io.http.version>2.2.0</siddhi.io.http.version>
         <siddhi.io.twitter.version>2.0.0</siddhi.io.twitter.version>
         <siddhi.io.sqs.version>3.0.0</siddhi.io.sqs.version>
         <siddhi.io.websocket.version>3.0.0</siddhi.io.websocket.version>

--- a/pom.xml
+++ b/pom.xml
@@ -930,11 +930,11 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.7.3</msf4j.version>
-        <com.fasterxml.jackson.core.version>2.8.9</com.fasterxml.jackson.core.version>
+        <msf4j.version>2.7.7</msf4j.version>
+        <com.fasterxml.jackson.core.version>2.9.8</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
-        <pax.logging.api.version>1.8.5</pax.logging.api.version>
+        <pax.logging.api.version>1.10.1</pax.logging.api.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
 
         <!--Event simulator-->
@@ -1021,7 +1021,7 @@
         <org.snakeyaml.version>1.17</org.snakeyaml.version>
         <mysql.con.version>6.0.5</mysql.con.version>
         <googlecode.json-simple.version>1.1.wso2v1</googlecode.json-simple.version>
-        <io.netty.version>4.1.19.Final</io.netty.version>
+        <io.netty.version>4.1.30.Final</io.netty.version>
         <log4j.version>1.2.17</log4j.version>
         <commons-codec.wso2.version>1.3.0.wso2v1</commons-codec.wso2.version>
 
@@ -1032,6 +1032,14 @@
 
         <!-- Forget me tool -->
         <forgetme.tool.version>1.1.21</forgetme.tool.version>
+
+        <!-- Java 11 related dependencies -->
+        <javax.annotation.version>1.3.2</javax.annotation.version>
+        <org.wso2.orbit.javax.xml.bind.version>2.3.1.wso2v1</org.wso2.orbit.javax.xml.bind.version>
+        <com.sun.xml.bind.version>2.4.0-b180830.0438</com.sun.xml.bind.version>
+        <org.apache.geronimo.spec.version>1.1</org.apache.geronimo.spec.version>
+        <com.sun.istack.version>3.0.8</com.sun.istack.version>
+        <com.sun.activation.version>1.2.0</com.sun.activation.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
This will fix the following issues,
* https://github.com/wso2/streaming-integrator/issues/40
* https://github.com/wso2/streaming-integrator/issues/60

And following extensions have been removed from the SI pack to reduce the distribution size. 
With the new [extension installation feature](https://ei.docs.wso2.com/en/7.1.0/streaming-integrator/connectors/downloading-and-Installing-Siddhi-Extensions/#downloading-and-installing-siddhi-extensions-via-the-command-line) required extensions can be installed into Streaming Integration Distribution

siddhi-execution-unique
siddhi-execution-regex
siddhi-execution-streamingml
siddhi-execution-markov
siddhi-execution-map
siddhi-execution-graph
siddhi-execution-timeseries
siddhi-execution-unitconversion
siddhi-execution-env
siddhi-execution-stats
siddhi-execution-list
siddhi-io-jms
siddhi-io-rabbitmq
siddhi-io-twitter
siddhi-io-sqs
siddhi-io-prometheus
siddhi-io-nats
siddhi-io-googlepubsub
siddhi-io-hl7
siddhi-io-gcs
siddhi-io-s3
siddhi-map-avro
siddhi-store-mongodb
siddhi-store-solr
siddhi-store-hbase
siddhi-store-cassandra
siddhi-store-redis
siddhi-io-mqtt
siddhi-store-elasticsearch
siddhi-store-influxdb
