### PR TITLE
Fix Issues in ETL Dashboards

### DIFF
--- a/modules/distribution/carbon-home/resources/dashboards/README.md
+++ b/modules/distribution/carbon-home/resources/dashboards/README.md
@@ -4,7 +4,7 @@ In order to use these dashboards with grafana you have to follow these instructi
 
 ## 1. Configuring Prometheus Reporter.  
 To enable statistics for the Prometheus Reporter, add the following configuration to deployment.yaml
-1. Navigate to `<WSO2_SI_HOME>/conf/runner/deployment.yaml`.
+1. Navigate to `<WSO2_SI_HOME>/conf/server/deployment.yaml`.
 2. Add following Configurations,
     ````
     wso2.metrics:
@@ -50,24 +50,24 @@ the Siddhi application name in the Siddhi file as shown in below.
 3. Add following configurations under the `scrape_configs:`  
     ````
     scrape_configs:
-      - job_name: 'prometheus'
+      - job_name: 'wso2'
         static_configs:
         - targets: ['localhost:9005']
     ````  
 4. Start the prometheus server by executing following command in the terminal `./prometheus`
 
-## 4. Start & Configure the grafana Server.
-1. Download grafana from the following URL  https://grafana.com/grafana/download  
+## 4. Start & Configure the Grafana Server.
+1. Download Grafana from the following URL  https://grafana.com/grafana/download  
 2. Extract the downloaded file and Navigate to grafana directory.  
 3. Issue following command in the console `bin/grafana-server`.  
 4. Navigate to grafana home with following URL `localhost:3000`.
-5. Then navigate `Create you first data source` and select `Prometheus`.
+5. Then navigate `Create your first data source` and select `Prometheus`.
 6. Then update the configurations as shown in below,    
 ![](./image-2.jpg)
 
 
-## 5. Load dashboards into grafana.
-Once you have login to the grafana follow these steps to import dashboards into grafana
+## 5. Load dashboards into Grafana.
+Once you have login to the Grafana follow these steps to import dashboards into Grafana
 
 1. Navigate to +(plus) icon at the left upper corner.  
 ![](./image-1.png)

--- a/modules/distribution/carbon-home/resources/dashboards/cdc-statistics/WSO2 Streaming Integrator - CDC Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/cdc-statistics/WSO2 Streaming Integrator - CDC Statistics.json
@@ -763,7 +763,7 @@
           "expr": "increase(siddhi_cdc_source_polling_mode_event_count{app=~\"$app\"}[$__interval])",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "{{tablename}}",
+          "legendFormat": "{{D_tablename}}",
           "refId": "B"
         }
       ],

--- a/modules/distribution/carbon-home/resources/dashboards/file-statistics/WSO2 Streaming Integrator - File Source Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/file-statistics/WSO2 Streaming Integrator - File Source Statistics.json
@@ -229,7 +229,7 @@
       "thresholds": "",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Read Lines",
+      "title": "Total Lines",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1494,7 +1494,7 @@
           "text": "None",
           "value": ""
         },
-        "datasource": "PrometheusGrafana",
+        "datasource": "Prometheus",
         "definition": "label_values(siddhi_file_apps, app)",
         "hide": 2,
         "includeAll": false,

--- a/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
@@ -137,6 +137,7 @@
       },
       "hiddenSeries": false,
       "id": 10,
+      "interval": "1m",
       "legend": {
         "alignAsTable": true,
         "avg": true,

--- a/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
@@ -137,7 +137,6 @@
       },
       "hiddenSeries": false,
       "id": 10,
-      "interval": "1m",
       "legend": {
         "alignAsTable": true,
         "avg": true,

--- a/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
@@ -1026,7 +1026,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum(siddhi_file_source_dropped_events{ app=~\"$app\"} + (siddhi_file_source_event_count{app=~\"$app\"} - ignoring(file_name, mode, stream_name)siddhi_file_source_total_valid_events_count{app=~\"$app\"}) + siddhi_file_source_error_count{app=~\"$app\"}) by (file_path)",
+          "expr": "sum((siddhi_file_source_event_count{app=~\"$app\"} - ignoring(file_name, mode, stream_name)siddhi_file_source_total_valid_events_count{app=~\"$app\"}) + siddhi_file_source_error_count{app=~\"$app\"}) by (file_path)",
           "format": "table",
           "hide": false,
           "instant": true,

--- a/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - Overall Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - Overall Statistics.json
@@ -402,7 +402,6 @@
       },
       "hiddenSeries": false,
       "id": 11,
-      "interval": "1m",
       "legend": {
         "alignAsTable": true,
         "avg": true,

--- a/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - Overall Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - Overall Statistics.json
@@ -402,6 +402,7 @@
       },
       "hiddenSeries": false,
       "id": 11,
+      "interval": "1m",
       "legend": {
         "alignAsTable": true,
         "avg": true,


### PR DESCRIPTION
## Purpose
* Update Readme
* Show file source error count in-app statistic level
* Change legend variable of the CDC statistics dashboard
* Remove the invalid data source of the file-source dashboard

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
* OS: Linux
* Prometheus v 2.19.2
* Grafana 6.5.2
 