### PR TITLE
Set Min time interval to 1m

### DIFF
--- a/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - App Statistics.json
@@ -137,6 +137,7 @@
       },
       "hiddenSeries": false,
       "id": 10,
+      "interval": "1m",
       "legend": {
         "alignAsTable": true,
         "avg": true,

--- a/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - Overall Statistics.json
+++ b/modules/distribution/carbon-home/resources/dashboards/overview-statistics/WSO2 Streaming Integrator - Overall Statistics.json
@@ -402,6 +402,7 @@
       },
       "hiddenSeries": false,
       "id": 11,
+      "interval": "1m",
       "legend": {
         "alignAsTable": true,
         "avg": true,


### PR DESCRIPTION
## Purpose
The widget uses `$__interval` property. Currently, the **Min time interval** was not set. Due to this, some graph widgets don't show any data. This PR set **Min time interval** as 1m.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
