### PR TITLE
Upgrade msf4j version to bump the netty components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -931,7 +931,7 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.8.5</msf4j.version>
+        <msf4j.version>2.8.6</msf4j.version>
         <com.fasterxml.jackson.core.version>2.9.10</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.databind.version>2.9.10.8</com.fasterxml.jackson.databind.version>
         <io.swagger.version>1.5.22</io.swagger.version>


### PR DESCRIPTION
## Purpose
When we start a SI 4.1.0 pack on aarch64 architecture, an error is thrown due to an issue in netty components below version `4.1.79.Final`. Since MSF4J is packing the netty components to SI and SI tooling, This PR will upgrade the msf4j version to `2.8.6` which contains the latest(`4.1.81.Final`) netty components.

Fixes https://github.com/wso2/api-manager/issues/723