### PR TITLE
Upgrade third-party dependencies for 4.2.0 release

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -44,6 +44,7 @@
                 <exclude>conf/deployment.yaml</exclude>
                 <exclude>conf/log4j2.xml</exclude>
                 <exclude>conf/transports/netty-transports.yml</exclude>
+                <exclude>wso2/lib/plugins/com.google.guava_23.0.0.jar</exclude>
                 <exclude>**/*.ipr</exclude>
                 <exclude>**/*.iwr</exclude>
                 <exclude>**/*.eclipse</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1079,10 +1079,10 @@
 
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
-        <carbon.analytics.version>3.0.66</carbon.analytics.version>
+        <carbon.analytics.version>3.0.67</carbon.analytics.version>
         <siddhi.version>5.1.26</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.63</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.64</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
@@ -1124,7 +1124,7 @@
         <carbon.utils.version>2.1.1</carbon.utils.version>
         <carbon.config.version>2.1.16</carbon.config.version>
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
-        <carbon.securevault.version>5.0.16</carbon.securevault.version>
+        <carbon.securevault.version>5.0.18</carbon.securevault.version>
 
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)
@@ -1172,7 +1172,7 @@
         <guava.version>31.1-jre</guava.version>
         <guava.bundle.version>31.1.0.jre</guava.bundle.version>
         <gson.version>2.8.5</gson.version>
-        <quartz.version>2.3.0.wso2v3</quartz.version>
+        <quartz.version>2.3.2.wso2v1</quartz.version>
         <metrics.version>3.2.5</metrics.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <commons-collections4.version>4.0</commons-collections4.version>
@@ -1180,7 +1180,7 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.8.7</msf4j.version>
+        <msf4j.version>2.8.10</msf4j.version>
         <com.fasterxml.jackson.core.version>2.9.10</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.databind.version>2.9.10.8</com.fasterxml.jackson.databind.version>
         <io.swagger.version>1.5.22</io.swagger.version>


### PR DESCRIPTION
## Purpose
This PR upgrades the following set of dependencies in SI 4.2.0 to a newer version.
- snakeyaml
- commons-io
- netty
- quartz
- jackson
- guava

Fixes https://github.com/wso2/api-manager/issues/1239
Fixes https://github.com/wso2/api-manager/issues/1236
Fixes https://github.com/wso2/api-manager/issues/1243
Fixes https://github.com/wso2/api-manager/issues/1235
Fixes https://github.com/wso2/api-manager/issues/1242
