### PR TITLE
Add jdk 17 support to the version check

### DIFF
--- a/modules/distribution/carbon-home/bin/jartobundle.bat
+++ b/modules/distribution/carbon-home/bin/jartobundle.bat
@@ -51,17 +51,17 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+:checkJdk
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0] 17.[0]" >NUL
 IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
+goto jdk
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
+echo [ERROR] CARBON is supported only on JDK 1.8, 11 and 17
+goto jdk
 
-:jdk16
+:jdk
 goto runTool
 
 :runTool

--- a/modules/distribution/carbon-home/bin/jartobundle.sh
+++ b/modules/distribution/carbon-home/bin/jartobundle.sh
@@ -109,9 +109,9 @@ fi
 
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10, 11 and 17"
    exit 1
 fi
 


### PR DESCRIPTION
## Purpose

- Added the version check for JDK 17.
- Fixed https://github.com/wso2/api-manager/issues/2243.

## Approach
- Added the version check for JDK 17 in both bat ans sh scripts.
- Refactored the bat file.