### PR TITLE
chore: update versions to 4.4.0-alpha for SI alpha release

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0-alpha</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0-alpha</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/osgi-tests/pom.xml
+++ b/modules/osgi-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0-alpha</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/osgi-tests/pom.xml
+++ b/modules/osgi-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/osgi-tests/test-distribution/pom.xml
+++ b/modules/osgi-tests/test-distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/osgi-tests/test-distribution/pom.xml
+++ b/modules/osgi-tests/test-distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0-alpha</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/osgi-tests/tests/pom.xml
+++ b/modules/osgi-tests/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/osgi-tests/tests/pom.xml
+++ b/modules/osgi-tests/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0-alpha</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/performance/pom.xml
+++ b/modules/performance/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0-alpha</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/performance/pom.xml
+++ b/modules/performance/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-streaming-integrator-parent</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.wso2.ei</groupId>
     <artifactId>wso2-streaming-integrator-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>4.4.0-alpha</version>
     <name>WSO2 Streaming Integrator - Parent</name>
 
     <url>http://wso2.org</url>
@@ -1208,10 +1208,10 @@
 
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
-        <carbon.analytics.version>3.0.77-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>5.1.32-SNAPSHOT</siddhi.version>
+        <carbon.analytics.version>3.0.77-alpha</carbon.analytics.version>
+        <siddhi.version>5.1.32-alpha</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.70-SNAPSHOT</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.71-alpha</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.wso2.ei</groupId>
     <artifactId>wso2-streaming-integrator-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.3.2-SNAPSHOT</version>
+    <version>4.4.0-SNAPSHOT</version>
     <name>WSO2 Streaming Integrator - Parent</name>
 
     <url>http://wso2.org</url>
@@ -939,6 +939,101 @@
                 <version>${carbon.kernel.version}</version>
                 <type>zip</type>
             </dependency>
+            <!-- Vulnerability fix: override transitive nimbus-jose-jwt -->
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus.jose.jwt.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: override transitive bouncycastle -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: override transitive commons-compress -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons.compress.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: override transitive commons-collections4 -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>${commons-collections4.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: override transitive netty -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${io.netty.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: override transitive c3p0 / mchange -->
+            <dependency>
+                <groupId>com.mchange</groupId>
+                <artifactId>c3p0</artifactId>
+                <version>${mchange.c3p0.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mchange</groupId>
+                <artifactId>mchange-commons-java</artifactId>
+                <version>${mchange.commons.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: override transitive libthrift -->
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>${libthrift.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: override transitive org.json -->
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${org.json.version}</version>
+            </dependency>
+            <!-- Vulnerability fix: ban log4j 1.x globally -->
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1113,10 +1208,10 @@
 
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
-        <carbon.analytics.version>3.0.76</carbon.analytics.version>
-        <siddhi.version>5.1.31</siddhi.version>
+        <carbon.analytics.version>3.0.77-SNAPSHOT</carbon.analytics.version>
+        <siddhi.version>5.1.32-SNAPSHOT</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.69</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.70-SNAPSHOT</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
@@ -1212,15 +1307,15 @@
         <gson.version>2.9.1</gson.version>
         <quartz.version>2.3.2.wso2v1</quartz.version>
         <metrics.version>3.2.5</metrics.version>
-        <commons-lang3.version>3.3.2</commons-lang3.version>
-        <commons-collections4.version>4.0</commons-collections4.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-collections4.version>4.4</commons-collections4.version>
         <kafka-2.10.version>0.8.1.1</kafka-2.10.version>
-        <common.collections4.version>4.0</common.collections4.version>
+        <common.collections4.version>4.4</common.collections4.version>
 
         <!--MSF4J related-->
         <msf4j.version>2.8.13</msf4j.version>
-        <com.fasterxml.jackson.core.version>2.16.0</com.fasterxml.jackson.core.version>
-        <com.fasterxml.jackson.databind.version>2.16.0</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.core.version>2.18.6</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.databind.version>2.18.6</com.fasterxml.jackson.databind.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
         <pax.logging.api.version>2.1.0-wso2v3</pax.logging.api.version>
@@ -1236,9 +1331,9 @@
         <fabricator.wso2v1.version>2.1.4.wso2v1</fabricator.wso2v1.version>
         <generex.wso2v1.version>1.0.0.wso2v1</generex.wso2v1.version>
 
-        <mysql.connector.version>5.1.38</mysql.connector.version>
+        <mysql.connector.version>5.1.49</mysql.connector.version>
         <ojdbc6.version>12.1.0.1-atlassian-hosted</ojdbc6.version>
-        <postgresql.version>42.1.4</postgresql.version>
+        <postgresql.version>42.2.28</postgresql.version>
         <h2.connector.version>2.2.224</h2.connector.version>
         <mssql-jdbc.version>8.2.0.jre8</mssql-jdbc.version>
         <zkclient.version>0.10</zkclient.version>
@@ -1295,8 +1390,15 @@
         <org.snakeyaml.version>2.2</org.snakeyaml.version>
         <mysql.con.version>6.0.5</mysql.con.version>
         <googlecode.json-simple.version>1.1.wso2v1</googlecode.json-simple.version>
-        <io.netty.version>4.1.118.Final</io.netty.version>
-        <log4j.version>2.17.1</log4j.version>
+        <io.netty.version>4.1.132.Final</io.netty.version>
+        <log4j.version>2.24.3</log4j.version>
+        <nimbus.jose.jwt.version>9.37.4</nimbus.jose.jwt.version>
+        <bouncycastle.version>1.78.1</bouncycastle.version>
+        <commons.compress.version>1.26.0</commons.compress.version>
+        <mchange.c3p0.version>0.12.0</mchange.c3p0.version>
+        <mchange.commons.version>0.4.0</mchange.commons.version>
+        <libthrift.version>0.16.0</libthrift.version>
+        <org.json.version>20231013</org.json.version>
         <commons-codec.wso2.version>1.3.0.wso2v1</commons-codec.wso2.version>
 
         <!--Performance Testing Versions-->


### PR DESCRIPTION
## Summary
- Update root and all submodule pom versions from `4.4.0-SNAPSHOT` to `4.4.0-alpha`
- Update dependency properties:
  - `carbon.analytics.version` → `3.0.77-alpha`
  - `carbon.analytics-common.version` → `6.1.71-alpha`
  - `siddhi.version` → `5.1.32-alpha` (already set)
- Part of the SI alpha release preparation across all component repos

## Changes
- 7 pom.xml files updated (root + all submodules + dependency properties)

## Related PRs
- siddhi: `5.1.32-alpha`
- carbon-analytics-common: `6.1.71-alpha`
- carbon-analytics: `3.0.77-alpha`
- siddhi-plugin-vscode: `0.1.0-alpha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)