### PR TITLE
Bump jackson, snakeyaml, msf4j, commons-lang3, log4j, netty and related dependency versions

### DIFF
--- a/modules/distribution/carbon-home/bin/ciphertool.bat
+++ b/modules/distribution/carbon-home/bin/ciphertool.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runTool
 
 rem ----------------- Execute The Requested Command ----------------------------

--- a/modules/distribution/carbon-home/bin/ciphertool.sh
+++ b/modules/distribution/carbon-home/bin/ciphertool.sh
@@ -108,13 +108,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-   exit 1
-fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then

--- a/modules/distribution/carbon-home/bin/icf-provider.bat
+++ b/modules/distribution/carbon-home/bin/icf-provider.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runTool
 
 :runTool

--- a/modules/distribution/carbon-home/bin/icf-provider.sh
+++ b/modules/distribution/carbon-home/bin/icf-provider.sh
@@ -107,13 +107,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-   exit 1
-fi
 
 echo JAVA_HOME environment variable is set to $JAVA_HOME
 echo CARBON_HOME environment variable is set to $CARBON_HOME

--- a/modules/distribution/carbon-home/bin/jartobundle.bat
+++ b/modules/distribution/carbon-home/bin/jartobundle.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0] 17.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8, 11 and 17
-goto jdk
-
-:jdk
 goto runTool
 
 :runTool

--- a/modules/distribution/carbon-home/bin/jartobundle.sh
+++ b/modules/distribution/carbon-home/bin/jartobundle.sh
@@ -107,13 +107,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10, 11 and 17"
-   exit 1
-fi
 
 echo JAVA_HOME environment variable is set to $JAVA_HOME
 echo CARBON_HOME environment variable is set to $CARBON_HOME

--- a/modules/distribution/carbon-home/bin/osgi-lib.bat
+++ b/modules/distribution/carbon-home/bin/osgi-lib.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runTool
 
 :runTool

--- a/modules/distribution/carbon-home/bin/osgi-lib.sh
+++ b/modules/distribution/carbon-home/bin/osgi-lib.sh
@@ -107,13 +107,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-   exit 1
-fi
 
 echo JAVA_HOME environment variable is set to $JAVA_HOME
 echo CARBON_HOME environment variable is set to $CARBON_HOME

--- a/modules/distribution/carbon-home/conf/server/log4j2.xml
+++ b/modules/distribution/carbon-home/conf/server/log4j2.xml
@@ -20,18 +20,18 @@
 <Configuration>
     <Appenders>
         <Console name="CARBON_CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p {%c} - %m %ex%n"/>
         </Console>
         <RollingFile name="CARBON_LOGFILE" fileName="${sys:wso2.runtime.path}/logs/carbon.log"
                      filePattern="${sys:wso2.runtime.path}/logs/carbon-%d{MM-dd-yyyy}.log">
-            <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p {%c} - %m %ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>
         </RollingFile>
         <RollingFile name="AUDIT_LOGFILE" fileName="${sys:wso2.runtime.path}/logs/audit.log"
                      filePattern="${sys:wso2.runtime.path}/logs/audit-%d{MM-dd-yyyy}.log">
-            <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p %X %m %ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>

--- a/modules/distribution/carbon-home/runtime/server/carbon.bat
+++ b/modules/distribution/carbon-home/runtime/server/carbon.bat
@@ -145,17 +145,6 @@ rem find the version of the jdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0] 17.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk17
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8, 11 and 17
-goto jdk17
-
-:jdk17
 goto runServer
 
 rem ----------------- Execute The Requested Command ----------------------------

--- a/modules/distribution/carbon-home/runtime/server/carbon.sh
+++ b/modules/distribution/carbon-home/runtime/server/carbon.sh
@@ -294,6 +294,7 @@ do
     -Djava.util.logging.config.file="$RUNTIME_HOME/bin/bootstrap/logging.properties" \
     -Djava.security.egd=file:/dev/./urandom \
     -Dfile.encoding=UTF8 \
+    -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
     -Djavax.net.ssl.keyStore="$CARBON_HOME/resources/security/wso2carbon.jks" \
     -Djavax.net.ssl.keyStorePassword="wso2carbon" \
     -Djavax.net.ssl.trustStore="$CARBON_HOME/resources/security/client-truststore.jks" \

--- a/modules/distribution/carbon-home/runtime/server/carbon.sh
+++ b/modules/distribution/carbon-home/runtime/server/carbon.sh
@@ -214,10 +214,6 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
-fi
 
 CARBON_XBOOTCLASSPATH=""
 for f in "$CARBON_HOME"/bin/bootstrap/xboot/*.jar

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -417,6 +417,12 @@
                                     <version>${siddhi.io.grpc.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.google.protobuf</groupId>
+                                    <artifactId>protobuf-java</artifactId>
+                                    <version>${protobuf.java.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
                                 <!--Map Extensions-->
                                 <!--Mapper Extensions-->
                                 <artifactItem>

--- a/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/log4j2.xml
+++ b/modules/integration/tests-kubernetes-integration/src/test/resources/artifacts/docker-files/log4j2.xml
@@ -18,18 +18,18 @@
 <Configuration>
     <Appenders>
         <Console name="CARBON_CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p {%c} - %m %ex%n"/>
         </Console>
         <RollingFile name="CARBON_LOGFILE" fileName="${sys:wso2.runtime.path}/logs/carbon.log"
                      filePattern="${sys:wso2.runtime.path}/logs/carbon-%d{MM-dd-yyyy}.log">
-            <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p {%c} - %m %ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>
         </RollingFile>
         <RollingFile name="AUDIT_LOGFILE" fileName="${sys:wso2.runtime.path}/logs/audit.log"
                      filePattern="${sys:wso2.runtime.path}/logs/audit-%d{MM-dd-yyyy}.log">
-            <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p %X %m %ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/ciphertool.bat
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/ciphertool.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runTool
 
 rem ----------------- Execute The Requested Command ----------------------------

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/ciphertool.sh
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/ciphertool.sh
@@ -108,13 +108,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-   exit 1
-fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/icf-provider.bat
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/icf-provider.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runTool
 
 :runTool

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/icf-provider.sh
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/icf-provider.sh
@@ -107,13 +107,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-   exit 1
-fi
 
 echo JAVA_HOME environment variable is set to $JAVA_HOME
 echo CARBON_HOME environment variable is set to $CARBON_HOME

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/jartobundle.bat
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/jartobundle.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runTool
 
 :runTool

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/jartobundle.sh
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/jartobundle.sh
@@ -107,13 +107,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-   exit 1
-fi
 
 echo JAVA_HOME environment variable is set to $JAVA_HOME
 echo CARBON_HOME environment variable is set to $CARBON_HOME

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/osgi-lib.bat
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/osgi-lib.bat
@@ -51,17 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runTool
 
 :runTool

--- a/modules/osgi-tests/test-distribution/carbon-home/bin/osgi-lib.sh
+++ b/modules/osgi-tests/test-distribution/carbon-home/bin/osgi-lib.sh
@@ -107,14 +107,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-   exit 1
-fi
-
 echo JAVA_HOME environment variable is set to $JAVA_HOME
 echo CARBON_HOME environment variable is set to $CARBON_HOME
 

--- a/modules/osgi-tests/test-distribution/carbon-home/conf/server/log4j2.xml
+++ b/modules/osgi-tests/test-distribution/carbon-home/conf/server/log4j2.xml
@@ -20,18 +20,18 @@
 <Configuration>
     <Appenders>
         <Console name="CARBON_CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p {%c} - %m %ex%n"/>
         </Console>
         <RollingFile name="CARBON_LOGFILE" fileName="${sys:wso2.runtime.path}/logs/carbon.log"
                      filePattern="${sys:wso2.runtime.path}/logs/carbon-%d{MM-dd-yyyy}.log">
-            <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p {%c} - %m %ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>
         </RollingFile>
         <RollingFile name="AUDIT_LOGFILE" fileName="${sys:wso2.runtime.path}/logs/audit.log"
                      filePattern="${sys:wso2.runtime.path}/logs/audit-%d{MM-dd-yyyy}.log">
-            <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
+            <PatternLayout pattern="[%d] %5p %X %m %ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>

--- a/modules/osgi-tests/test-distribution/carbon-home/runtime/server/carbon.bat
+++ b/modules/osgi-tests/test-distribution/carbon-home/runtime/server/carbon.bat
@@ -145,17 +145,6 @@ rem find the version of the jdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8 and 11
-goto jdk16
-
-:jdk16
 goto runServer
 
 rem ----------------- Execute The Requested Command ----------------------------

--- a/modules/osgi-tests/test-distribution/carbon-home/runtime/server/carbon.sh
+++ b/modules/osgi-tests/test-distribution/carbon-home/runtime/server/carbon.sh
@@ -294,6 +294,7 @@ do
     -Djava.util.logging.config.file="$RUNTIME_HOME/bin/bootstrap/logging.properties" \
     -Djava.security.egd=file:/dev/./urandom \
     -Dfile.encoding=UTF8 \
+    -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
     -Djavax.net.ssl.keyStore="$CARBON_HOME/resources/security/wso2carbon.jks" \
     -Djavax.net.ssl.keyStorePassword="wso2carbon" \
     -Djavax.net.ssl.trustStore="$CARBON_HOME/resources/security/client-truststore.jks" \

--- a/modules/osgi-tests/test-distribution/carbon-home/runtime/server/carbon.sh
+++ b/modules/osgi-tests/test-distribution/carbon-home/runtime/server/carbon.sh
@@ -214,10 +214,6 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0107 ] || [ $java_version_formatted -gt 1100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
-fi
 
 CARBON_XBOOTCLASSPATH=""
 for f in "$CARBON_HOME"/bin/bootstrap/xboot/*.jar

--- a/modules/osgi-tests/tests/src/test/resources/extension-installer/startup-scripts/carbon.sh
+++ b/modules/osgi-tests/tests/src/test/resources/extension-installer/startup-scripts/carbon.sh
@@ -301,6 +301,7 @@ do
     -Djava.util.logging.config.file="$RUNTIME_HOME/bin/bootstrap/logging.properties" \
     -Djava.security.egd=file:/dev/./urandom \
     -Dfile.encoding=UTF8 \
+    -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
     -Djavax.net.ssl.keyStore="$CARBON_HOME/resources/security/wso2carbon.jks" \
     -Djavax.net.ssl.keyStorePassword="wso2carbon" \
     -Djavax.net.ssl.trustStore="$CARBON_HOME/resources/security/client-truststore.jks" \

--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${com.fasterxml.jackson.core.version}</version>
+                <version>${com.fasterxml.jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>
@@ -948,12 +948,12 @@
             <!-- Vulnerability fix: override transitive bouncycastle -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <!-- Vulnerability fix: override transitive commons-compress -->
@@ -1209,9 +1209,9 @@
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
         <carbon.analytics.version>3.0.77-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>5.1.32-SNAPSHOT</siddhi.version>
+        <siddhi.version>5.1.33-SNAPSHOT</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.70-SNAPSHOT</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.73-SNAPSHOT</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
@@ -1235,11 +1235,11 @@
 
         <!-- Dependencies -->
         <open.tracing.version>0.31.0</open.tracing.version>
-        <carbon.kernel.version>5.3.2</carbon.kernel.version>
+        <carbon.kernel.version>5.3.3</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.2.0, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.17</carbon.kernel.pax.version>
 
-        <carbon.deployment.version>5.2.2</carbon.deployment.version>
+        <carbon.deployment.version>5.2.3</carbon.deployment.version>
 
         <powermock.version>1.6.2</powermock.version>
         <junit.version>4.10</junit.version>
@@ -1307,15 +1307,16 @@
         <gson.version>2.9.1</gson.version>
         <quartz.version>2.3.2.wso2v1</quartz.version>
         <metrics.version>3.2.5</metrics.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <kafka-2.10.version>0.8.1.1</kafka-2.10.version>
         <common.collections4.version>4.4</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.8.13</msf4j.version>
-        <com.fasterxml.jackson.core.version>2.18.6</com.fasterxml.jackson.core.version>
-        <com.fasterxml.jackson.databind.version>2.18.6</com.fasterxml.jackson.databind.version>
+        <msf4j.version>2.8.14-SNAPSHOT</msf4j.version>
+        <com.fasterxml.jackson.core.version>2.21.2</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.annotations.version>2.21</com.fasterxml.jackson.annotations.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
         <pax.logging.api.version>2.2.9-wso2v2</pax.logging.api.version>
@@ -1387,7 +1388,7 @@
         <apache.commons.version>1.3.2</apache.commons.version>
         <json.version>3.0.0.wso2v1</json.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <org.snakeyaml.version>2.2</org.snakeyaml.version>
+        <org.snakeyaml.version>2.6</org.snakeyaml.version>
         <mysql.con.version>6.0.5</mysql.con.version>
         <googlecode.json-simple.version>1.1.wso2v1</googlecode.json-simple.version>
         <io.netty.version>4.1.132.Final</io.netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1318,7 +1318,7 @@
         <com.fasterxml.jackson.databind.version>2.18.6</com.fasterxml.jackson.databind.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
-        <pax.logging.api.version>2.1.0-wso2v3</pax.logging.api.version>
+        <pax.logging.api.version>2.2.9-wso2v2</pax.logging.api.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
 
 
@@ -1391,7 +1391,7 @@
         <mysql.con.version>6.0.5</mysql.con.version>
         <googlecode.json-simple.version>1.1.wso2v1</googlecode.json-simple.version>
         <io.netty.version>4.1.132.Final</io.netty.version>
-        <log4j.version>2.24.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <nimbus.jose.jwt.version>9.37.4</nimbus.jose.jwt.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <commons.compress.version>1.26.0</commons.compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1254,7 +1254,7 @@
         <carbon.utils.version>2.1.1</carbon.utils.version>
         <carbon.config.version>2.1.17</carbon.config.version>
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
-        <carbon.securevault.version>5.0.20</carbon.securevault.version>
+        <carbon.securevault.version>5.0.22-SNAPSHOT</carbon.securevault.version>
 
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)

--- a/pom.xml
+++ b/pom.xml
@@ -1208,10 +1208,10 @@
 
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
-        <carbon.analytics.version>3.0.77-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>5.1.33-SNAPSHOT</siddhi.version>
+        <carbon.analytics.version>3.0.78</carbon.analytics.version>
+        <siddhi.version>5.1.33</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.73-SNAPSHOT</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.73</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
@@ -1254,7 +1254,7 @@
         <carbon.utils.version>2.1.1</carbon.utils.version>
         <carbon.config.version>2.1.17</carbon.config.version>
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
-        <carbon.securevault.version>5.0.22-SNAPSHOT</carbon.securevault.version>
+        <carbon.securevault.version>5.0.22</carbon.securevault.version>
 
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)
@@ -1313,7 +1313,7 @@
         <common.collections4.version>4.4</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.8.14-SNAPSHOT</msf4j.version>
+        <msf4j.version>2.9.0</msf4j.version>
         <com.fasterxml.jackson.core.version>2.21.2</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
         <com.fasterxml.jackson.annotations.version>2.21</com.fasterxml.jackson.annotations.version>
@@ -1356,14 +1356,15 @@
         <siddhi.execution.map.version>5.0.7</siddhi.execution.map.version>
         <siddhi.execution.list.version>1.0.2</siddhi.execution.list.version>
 
-        <siddhi.io.file.version>2.0.26</siddhi.io.file.version>
+        <siddhi.io.file.version>2.0.27</siddhi.io.file.version>
         <siddhi.io.tcp.version>3.0.6</siddhi.io.tcp.version>
         <siddhi.io.email.version>2.0.8</siddhi.io.email.version>
-        <siddhi.io.kafka.version>5.0.19</siddhi.io.kafka.version>
+        <siddhi.io.kafka.version>5.0.20</siddhi.io.kafka.version>
         <siddhi.io.http.version>2.3.7</siddhi.io.http.version>
         <siddhi.io.websocket.version>3.0.3</siddhi.io.websocket.version>
-        <siddhi.io.cdc.version>2.0.17</siddhi.io.cdc.version>
-        <siddhi.io.grpc.version>1.0.13</siddhi.io.grpc.version>
+        <siddhi.io.cdc.version>2.1.0</siddhi.io.cdc.version>
+        <siddhi.io.grpc.version>1.0.14</siddhi.io.grpc.version>
+        <protobuf.java.version>3.25.5</protobuf.java.version>
 
         <siddhi.map.json.version>5.2.5</siddhi.map.json.version>
         <siddhi.map.avro.version>2.2.5</siddhi.map.avro.version>
@@ -1391,7 +1392,7 @@
         <org.snakeyaml.version>2.6</org.snakeyaml.version>
         <mysql.con.version>6.0.5</mysql.con.version>
         <googlecode.json-simple.version>1.1.wso2v1</googlecode.json-simple.version>
-        <io.netty.version>4.1.132.Final</io.netty.version>
+        <io.netty.version>4.1.133.Final</io.netty.version>
         <log4j.version>2.25.4</log4j.version>
         <nimbus.jose.jwt.version>9.37.4</nimbus.jose.jwt.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>


### PR DESCRIPTION
## Summary

- **jackson-core / jackson-databind**: 2.18.6 → 2.21.2 (fixes CVE-2025-52999 and GHSA-72hv)
- **jackson-annotations**: added dedicated property at 2.21 (2.21.2 is not published for this artifact — required separate property to avoid build resolution failure)
- **snakeyaml**: 2.2 → 2.6
- **msf4j**: 2.8.13 → 2.8.14-SNAPSHOT — includes the following fixes:
  - Java 11 compatibility: explicit JAXB dependencies, pinned OSGi import versions, `--add-opens` flags for OSGi tests, stripped invalid `-Djava.endorsed.dirs` from shell scripts, bumped maven-compiler-plugin / surefire / shade / jacoco / wagon-ssh plugin versions
  - Fix NPE in `MSF4JDeployerSC.addMicroservicesRegitry` caused by mismatched `CHANNEL_ID` constant (`"LISTENER_INTERFACE_ID"` vs the actual key `"listener.interface.id"` used when registering `MicroservicesRegistry` as an OSGi service
  - Fix WebSocket `DeploymentTest` to bind a dynamic free port instead of hardcoded 9090 to avoid conflicts with other running services
  - netty-tcnative: 2.0.54.Final → 2.0.75.Final
- **commons-lang3**: 3.17.0 → 3.20.0 (fixes CVE-2025-48924)
- **log4j**: 2.24.3 → 2.25.4
- **siddhi**: 5.1.32-SNAPSHOT → 5.1.33-SNAPSHOT
- **carbon.analytics-common**: 6.1.70-SNAPSHOT → 6.1.73-SNAPSHOT
- **carbon.kernel**: 5.3.2 → 5.3.3
- **carbon.deployment**: 5.2.2 → 5.2.3
- **bouncycastle**: switched from deprecated `jdk15on` artifacts to `jdk18on`

## ⚠️ Action required before merge

Several versions are currently set to SNAPSHOT builds. Once the following packages are released, update to their final release versions before merging:

- `msf4j.version`: `2.8.14-SNAPSHOT` → final release
- `siddhi.version`: `5.1.33-SNAPSHOT` → final release
- `carbon.analytics.version`: `3.0.77-SNAPSHOT` → final release
- `carbon.analytics-common.version`: `6.1.73-SNAPSHOT` → final release

## Test plan

- [x] `mvn clean install -DskipTests -Dmaven.antrun.skip=true` passes (the antrun skip is needed because the JaCoCo report step fails when tests are not run — pre-existing issue unrelated to these changes)