### PR TITLE
Fix bouncycastle artifact names for 1.78.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -948,12 +948,12 @@
             <!-- Vulnerability fix: override transitive bouncycastle -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <!-- Vulnerability fix: override transitive commons-compress -->

--- a/pom.xml
+++ b/pom.xml
@@ -1208,10 +1208,10 @@
 
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
-        <carbon.analytics.version>3.0.77-SNAPSHOT</carbon.analytics.version>
-        <siddhi.version>5.1.32-SNAPSHOT</siddhi.version>
+        <carbon.analytics.version>3.0.77</carbon.analytics.version>
+        <siddhi.version>5.1.32</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.70-SNAPSHOT</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.70</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>


### PR DESCRIPTION
## Summary
- Update `bcprov-jdk15on` → `bcprov-jdk18on` and `bcpkix-jdk15on` → `bcpkix-jdk18on` in dependency overrides
- BouncyCastle renamed these artifacts starting from version 1.78; version `1.78.1` does not exist under the old `jdk15on` artifact names
- Fixes dependency resolution failure during the 4.4.0-alpha release build

## Test plan
- [ ] Verify the release build resolves all dependencies successfully
- [ ] Confirm no runtime issues with the updated BouncyCastle artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated BouncyCastle library versions.
  * Released stable versions of Carbon Analytics and Siddhi dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->