### PR TITLE
Bump msf4j and carbon-kernel versions to fix Netty and log4j CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1235,7 +1235,8 @@
 
         <!-- Dependencies -->
         <open.tracing.version>0.31.0</open.tracing.version>
-        <carbon.kernel.version>5.3.3</carbon.kernel.version>
+        <!-- TODO: Remove -SNAPSHOT suffix once carbon-kernel 5.3.4 is released -->
+        <carbon.kernel.version>5.3.4-SNAPSHOT</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.2.0, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.17</carbon.kernel.pax.version>
 
@@ -1313,7 +1314,8 @@
         <common.collections4.version>4.4</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.9.0</msf4j.version>
+        <!-- TODO: Remove -SNAPSHOT suffix once msf4j 2.9.1 is released -->
+        <msf4j.version>2.9.1-SNAPSHOT</msf4j.version>
         <com.fasterxml.jackson.core.version>2.21.2</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
         <com.fasterxml.jackson.annotations.version>2.21</com.fasterxml.jackson.annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1208,11 +1208,10 @@
 
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
-        <carbon.analytics.version>3.0.78</carbon.analytics.version>
+        <carbon.analytics.version>3.0.79-SNAPSHOT</carbon.analytics.version>
         <siddhi.version>5.1.33</siddhi.version>
 
-        <!-- TODO: remove SNAPSHOT once carbon-analytics-common 6.1.74 is released -->
-        <carbon.analytics-common.version>6.1.74-SNAPSHOT</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.74</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
@@ -1236,8 +1235,7 @@
 
         <!-- Dependencies -->
         <open.tracing.version>0.31.0</open.tracing.version>
-        <!-- TODO: Remove -SNAPSHOT suffix once carbon-kernel 5.3.4 is released -->
-        <carbon.kernel.version>5.3.4-SNAPSHOT</carbon.kernel.version>
+        <carbon.kernel.version>5.3.4</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.2.0, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.17</carbon.kernel.pax.version>
 
@@ -1248,8 +1246,7 @@
         <osgi.test.util.version>5.1.1</osgi.test.util.version>
 
         <carbon.datasources.version>1.1.18</carbon.datasources.version>
-        <!-- TODO: remove SNAPSHOT once carbon-metrics 2.3.24 is released -->
-        <carbon.metrics.version>2.3.24-SNAPSHOT</carbon.metrics.version>
+        <carbon.metrics.version>2.3.24</carbon.metrics.version>
         <carbon.jndi.version>1.0.5</carbon.jndi.version>
 
         <carbon.cache.version>1.1.3</carbon.cache.version>
@@ -1316,8 +1313,7 @@
         <common.collections4.version>4.4</common.collections4.version>
 
         <!--MSF4J related-->
-        <!-- TODO: Remove -SNAPSHOT suffix once msf4j 2.9.1 is released -->
-        <msf4j.version>2.9.1-SNAPSHOT</msf4j.version>
+        <msf4j.version>2.9.1</msf4j.version>
         <com.fasterxml.jackson.core.version>2.21.2</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
         <com.fasterxml.jackson.annotations.version>2.21</com.fasterxml.jackson.annotations.version>
@@ -1360,13 +1356,13 @@
         <siddhi.execution.map.version>5.0.7</siddhi.execution.map.version>
         <siddhi.execution.list.version>1.0.2</siddhi.execution.list.version>
 
-        <siddhi.io.file.version>2.0.27</siddhi.io.file.version>
+        <siddhi.io.file.version>2.0.28</siddhi.io.file.version>
         <siddhi.io.tcp.version>3.0.6</siddhi.io.tcp.version>
         <siddhi.io.email.version>2.0.8</siddhi.io.email.version>
-        <siddhi.io.kafka.version>5.0.20</siddhi.io.kafka.version>
+        <siddhi.io.kafka.version>5.0.21</siddhi.io.kafka.version>
         <siddhi.io.http.version>2.3.7</siddhi.io.http.version>
         <siddhi.io.websocket.version>3.0.3</siddhi.io.websocket.version>
-        <siddhi.io.cdc.version>2.1.0</siddhi.io.cdc.version>
+        <siddhi.io.cdc.version>2.1.1</siddhi.io.cdc.version>
         <siddhi.io.grpc.version>1.0.14</siddhi.io.grpc.version>
         <protobuf.java.version>3.25.5</protobuf.java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1211,7 +1211,8 @@
         <carbon.analytics.version>3.0.78</carbon.analytics.version>
         <siddhi.version>5.1.33</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.73</carbon.analytics-common.version>
+        <!-- TODO: remove SNAPSHOT once carbon-analytics-common 6.1.74 is released -->
+        <carbon.analytics-common.version>6.1.74-SNAPSHOT</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
@@ -1247,7 +1248,8 @@
         <osgi.test.util.version>5.1.1</osgi.test.util.version>
 
         <carbon.datasources.version>1.1.18</carbon.datasources.version>
-        <carbon.metrics.version>2.3.23</carbon.metrics.version>
+        <!-- TODO: remove SNAPSHOT once carbon-metrics 2.3.24 is released -->
+        <carbon.metrics.version>2.3.24-SNAPSHOT</carbon.metrics.version>
         <carbon.jndi.version>1.0.5</carbon.jndi.version>
 
         <carbon.cache.version>1.1.3</carbon.cache.version>
@@ -1401,7 +1403,7 @@
         <commons.compress.version>1.26.0</commons.compress.version>
         <mchange.c3p0.version>0.12.0</mchange.c3p0.version>
         <mchange.commons.version>0.4.0</mchange.commons.version>
-        <libthrift.version>0.16.0</libthrift.version>
+        <libthrift.version>0.23.0</libthrift.version>
         <org.json.version>20231013</org.json.version>
         <commons-codec.wso2.version>1.3.0.wso2v1</commons-codec.wso2.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1208,7 +1208,7 @@
 
     <properties>
         <streaming.integration.version>${project.version}</streaming.integration.version>
-        <carbon.analytics.version>3.0.79-SNAPSHOT</carbon.analytics.version>
+        <carbon.analytics.version>3.0.79</carbon.analytics.version>
         <siddhi.version>5.1.33</siddhi.version>
 
         <carbon.analytics-common.version>6.1.74</carbon.analytics-common.version>


### PR DESCRIPTION
## Summary

- Points `carbon.kernel.version` to `5.3.4-SNAPSHOT` (fixes 4 MEDIUM log4j CVEs via pax-logging-log4j2 wso2v3 / log4j-core 2.25.4)
- Points `msf4j.version` to `2.9.1-SNAPSHOT` (fixes 8 Netty CVEs via Netty 4.1.133.Final)
- Adds TODO comments on both SNAPSHOT properties as a reminder to remove the `-SNAPSHOT` suffix once the respective releases are cut

> **⚠️ SNAPSHOT dependency notice**
> `carbon.kernel.version` and `msf4j.version` are intentionally pinned to SNAPSHOT builds while the upstream fixes undergo review and release. Once `carbon-kernel 5.3.4` and `msf4j 2.9.1` are officially released, the `-SNAPSHOT` suffixes **must be removed** from `pom.xml`. Failing to do so will cause non-reproducible builds. The TODO comments in the file mark the exact lines.

## Upstream PRs

| Dependency | Fix PR |
|-----------|--------|
| msf4j — Netty 4.1.132 → 4.1.133 | https://github.com/wso2/msf4j/pull/647 |
| carbon-kernel — pax-logging wso2v2 → wso2v3 | https://github.com/wso2/carbon-kernel/pull/4593 |

## CVEs resolved

- **Finding D** — 8 CVEs (HIGH/MEDIUM/LOW) in `io.netty:*` at 4.1.132.Final; resolved in 4.1.133.Final
- **Finding E** — 4 CVEs (MEDIUM) in `log4j-core` 2.25.3 embedded in pax-logging-log4j2 wso2v2; resolved in 2.25.4 (wso2v3)

## Test plan

- [ ] Build with `mvn clean install -DskipTests` on Java 11 against the SNAPSHOT artifacts — expect success
- [ ] Verify pack contains all `io.netty.*` plugins at `4.1.133.Final`
- [ ] Verify pack contains `pax-logging-api_2.2.9.wso2v3.jar` and `pax-logging-log4j2_2.2.9.wso2v3.jar`
- [ ] Run grype binary scan on the pack: `grype dir:<pack>/wso2/lib/plugins` — expect 0 Netty and 0 log4j CVEs
- [ ] After upstream releases, replace both SNAPSHOT versions with the release versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)